### PR TITLE
#1 - Avoid empty decorations

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,0 +1,19 @@
+name: Build and test
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiptap-annotation-magic",
-  "version": "2.0.0np",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiptap-annotation-magic",
-      "version": "2.0.0np",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@tiptap/core": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tiptap-annotation-magic",
   "author": "Lucca Baumgärtner <kontakt@luccabaumgaertner.de>",
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {

--- a/src/extension/rendering/engine.spec.ts
+++ b/src/extension/rendering/engine.spec.ts
@@ -29,7 +29,7 @@ describe("Test conflicting annotation", () => {
   });
 });
 
-describe("Test sorting of annotaiton list", () => {
+describe("Test sorting of annotation list", () => {
   const testList: Annotation<any>[] = [
     {
       id: "abc",
@@ -370,6 +370,102 @@ describe("Mapping the annotation list to a flat representation", () => {
           displayName: "X",
           tag: "X",
           rendering: "fragment-right",
+        },
+      ],
+    },
+    {
+      name: "Exact overlap - from",
+      inputAnnotations: [
+        {
+          id: "abc",
+          from: 0,
+          to: 8,
+          displayName: "Y",
+          tag: "Y",
+        },
+        {
+          id: "abc",
+          from: 0,
+          to: 5,
+          displayName: "X",
+          tag: "X",
+        },
+        {
+          id: "abc",
+          from: 10,
+          to: 15,
+          displayName: "Z",
+          tag: "Z",
+        },
+      ],
+      flatMapping: [
+        {
+          id: "abc",
+          from: 0,
+          to: 5,
+          displayName: "X",
+          tag: "X",
+          rendering: "normal",
+        },
+        {
+          id: "abc",
+          from: 5,
+          to: 8,
+          displayName: "Y",
+          tag: "Y",
+          rendering: "fragment-right",
+        },
+        {
+          id: "abc",
+          from: 10,
+          to: 15,
+          displayName: "Z",
+          tag: "Z",
+          rendering: "normal",
+        },
+      ],
+    },
+    {
+      name: "Exact overlap - from and to",
+      inputAnnotations: [
+        {
+          id: "abc",
+          from: 0,
+          to: 8,
+          displayName: "X",
+          tag: "X",
+        },
+        {
+          id: "abc",
+          from: 0,
+          to: 8,
+          displayName: "Y",
+          tag: "Y",
+        },
+        {
+          id: "abc",
+          from: 10,
+          to: 15,
+          displayName: "Z",
+          tag: "Z",
+        },
+      ],
+      flatMapping: [
+        {
+          id: "abc",
+          from: 0,
+          to: 8,
+          displayName: "Y",
+          tag: "Y",
+          rendering: "normal",
+        },
+        {
+          id: "abc",
+          from: 10,
+          to: 15,
+          displayName: "Z",
+          tag: "Z",
+          rendering: "normal",
         },
       ],
     },

--- a/src/extension/rendering/engine.ts
+++ b/src/extension/rendering/engine.ts
@@ -29,11 +29,8 @@ export const createAnnotationRendering = (
 ): AnnotationFragment<any>[] => {
   const renderedAnnotations: AnnotationFragment<any>[] = [];
   const openAnnotationStack: ActionKeyframe[] = [];
-  //const actionMap: Map<number, ActionKeyframe[]> = new Map();
   const actionMap: ActionKeyframe[][] = [];
   const annotationFragmentation: boolean[] = [];
-
-  // annotations = sortAnnotationsByStart(annotations);
 
   // STEP 1: Create a Map, containing the rendering actions for each index in the document.
   // this could be opening or closing an annotation
@@ -87,7 +84,9 @@ export const createAnnotationRendering = (
               from,
               rendering,
             };
-            renderedAnnotations.push(normalTerm);
+            if (normalTerm.from < normalTerm.to) {
+              renderedAnnotations.push(normalTerm);
+            }
           } else if (
             actionStackPeek.action === "open" &&
             action.action === "close"
@@ -131,11 +130,13 @@ export const createAnnotationRendering = (
                 rendering: "fragment-left",
                 to: annotations[action.annotationIndex].from,
               };
-              // mark the previous annotation as fragmented, by saving where the fragment ends
+              // mark the previous annotation as fragmented
               annotationFragmentation[actionStackPeek.annotationIndex] = true;
             }
 
-            renderedAnnotations.push(fragment);
+            if (fragment.from < fragment.to) {
+              renderedAnnotations.push(fragment);
+            }
             openAnnotationStack.push(action);
           }
         } else if (action.action === "open") {


### PR DESCRIPTION
- Only render an annotation(-fragment) if `a.from < a.to`

Closes #1